### PR TITLE
Delete after 10 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change deletion timeout to 10 hours (was 8) to allow a test cluster to survive a full working day.
+
 ## [0.2.1] - 2021-12-09
 
 - Fix reconciling.

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -68,7 +68,7 @@ func TestClusterController(t *testing.T) {
 					Name:      "test",
 					Namespace: "default",
 					CreationTimestamp: metav1.Time{
-						Time: time.Now().Add(-9 * time.Hour),
+						Time: time.Now().Add(-11 * time.Hour),
 					},
 					Annotations: map[string]string{},
 					Finalizers: []string{

--- a/controllers/utility.go
+++ b/controllers/utility.go
@@ -13,7 +13,7 @@ const (
 	keepUntil             = "keep-until"
 
 	// defaultTTL is the default time to live for a cluster.
-	defaultTTL = 8 * time.Hour
+	defaultTTL = 10 * time.Hour
 
 	// eventDefaultTTL is the default time when we sent a `ClusterMarkedForDeletion` event.
 	eventDefaultTTL = defaultTTL - 1*time.Hour


### PR DESCRIPTION
If I create a cluster at 9am, I'd like it to survive at least until 6 PM.

this PR changes the deletion timeout from 8h to 10h.

WDYT?

## Checklist

- [x] Update changelog in CHANGELOG.md.

