### PR TITLE
Fix bug in logging + add missing test case for MC + RBAC (apps, configmaps for CAPI clusters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+- Test case for CAPI MC
+
+### Changed
+- Fix logging
 
 ## [0.6.0] - 2023-05-18
 - Added support for CAPI cluster

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Test case for CAPI MC
+- Added test case for CAPI MC
 
 ### Changed
-- Fix logging
+- Fixed logging
+- Updated RBAC permissions for cleaning up CAPI cluster
 
 ## [0.6.0] - 2023-05-18
 - Added support for CAPI cluster

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -78,14 +78,14 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *capi.Cluster
 	// ignore GitOps-managed resources
 	if _, ok := cluster.Labels[fluxLabel]; ok {
 		IgnoredTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()
-		log.Info("Found label %s. Cluster will be ignored for deletion", fluxLabel)
+		log.Info(fmt.Sprintf("Found label %s. Cluster will be ignored for deletion", fluxLabel))
 		return ctrl.Result{}, nil
 	}
 
 	// ignore cluster from being deleted if ignore annotation is set
 	if _, ok := cluster.Annotations[ignoreClusterDeletion]; ok {
 		IgnoredTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()
-		log.Info("Found annotation %s. Cluster will be ignored for deletion", ignoreClusterDeletion)
+		log.Info(fmt.Sprintf("Found annotation %s. Cluster will be ignored for deletion", ignoreClusterDeletion))
 		return ctrl.Result{}, nil
 	}
 
@@ -99,7 +99,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *capi.Cluster
 		}
 		if time.Now().UTC().Before(t) {
 			IgnoredTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()
-			log.Info("Found label %s. Cluster will be ignored for deletion", keepUntil)
+			log.Info(fmt.Sprintf("Found label %s. Cluster will be ignored for deletion", keepUntil))
 			return ctrl.Result{RequeueAfter: 24 * time.Hour}, nil
 		}
 	}
@@ -143,7 +143,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *capi.Cluster
 }
 
 func deleteVintageCluster(ctx context.Context, log logr.Logger, client ctrlclient.Client, cluster *capi.Cluster) error {
-	log.Info("Cluster is being deleted", cluster.Namespace, cluster.Name)
+	log.Info("Cluster is being deleted")
 	if err := client.Delete(ctx, cluster, ctrlclient.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
 		log.Error(err, "unable to delete cluster")
 		ErrorsTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -459,6 +459,22 @@ func TestClusterAppDeletion(t *testing.T) {
 					},
 				},
 				{
+					expectedDeletion: false,
+					app: &gsapplication.App{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test2",
+							Namespace: "default",
+							Labels: map[string]string{
+								label.Cluster:                      "test",
+								"kustomize.toolkit.fluxcd.io/name": "flux",
+							},
+							Finalizers: []string{
+								"test.giantswarm.io/keep",
+							},
+						},
+					},
+				},
+				{
 					expectedDeletion: true,
 					app: &gsapplication.App{
 						ObjectMeta: metav1.ObjectMeta{

--- a/helm/cluster-cleaner/templates/rbac.yaml
+++ b/helm/cluster-cleaner/templates/rbac.yaml
@@ -31,6 +31,7 @@ rules:
   - update
   - patch
   - delete
+  - deletecollection
 - apiGroups:
   - "application.giantswarm.io"
   resources:

--- a/helm/cluster-cleaner/templates/rbac.yaml
+++ b/helm/cluster-cleaner/templates/rbac.yaml
@@ -22,6 +22,7 @@ rules:
   - ""
   resources:
   - events
+  - configmaps
   verbs:
   - get
   - list
@@ -30,6 +31,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - "application.giantswarm.io"
+  resources:
+  - apps
+  verbs:
+  - "*"  
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Towards - https://github.com/giantswarm/roadmap/issues/1598

This PR:
- Fixes bug in logging causing operator to panic :( 
```
 panic: odd number of arguments passed as key-value pairs for logging
```
- Add missing test case for MC
- Add missing RBAC to delete cluster/default-apps apps and configmaps for CAPI clusters

## Checklist

- [x] Update changelog in CHANGELOG.md.

