### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
+
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [0.8.0] - 2023-07-17
 

--- a/helm/cluster-cleaner/values.yaml
+++ b/helm/cluster-cleaner/values.yaml
@@ -5,7 +5,7 @@ image:
   name: "giantswarm/cluster-cleaner"
   tag: "[[ .Version ]]"
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 dryRun: false
 
@@ -31,4 +31,4 @@ securityContext:
     type: RuntimeDefault
   capabilities:
     drop:
-    - ALL
+      - ALL


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
