### PR TITLE
Add cluster cleaner to all CAPI collections to ensure automatic updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,3 +32,51 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-capa-app-collection
+          app_name: "cluster-cleaner"
+          app_collection_repo: "capa-app-collection"
+          requires:
+            - push-cluster-cleaner-to-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-cloud-director-app-collection
+          app_name: "cluster-cleaner"
+          app_collection_repo: "cloud-director-app-collection"
+          requires:
+            - push-cluster-cleaner-to-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-vsphere-app-collection
+          app_name: "cluster-cleaner"
+          app_collection_repo: "vsphere-app-collection"
+          requires:
+            - push-cluster-cleaner-to-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-capz-app-collection
+          app_name: "cluster-cleaner"
+          app_collection_repo: "capz-app-collection"
+          requires:
+            - push-cluster-cleaner-to-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CircleCI job to push `cluster-cleaner` to  CAPA,CAPZ,CAPV and CAPVCD app collection.
+
 ## [0.9.0] - 2024-02-15
 
 ### Changed


### PR DESCRIPTION
### Added

- Add CircleCI job to push `cluster-cleaner` to  CAPA,CAPZ,CAPV and CAPVCD app collection.


towards https://github.com/giantswarm/giantswarm/issues/30431

 the app is guarded by https://github.com/giantswarm/cluster-cleaner/blob/main/helm/cluster-cleaner/templates/deployment.yaml#L1 which is set by default here - https://github.com/giantswarm/shared-configs/blob/main/default/apps/cluster-cleaner/configmap-values.yaml.template#L2