### PR TITLE
Do not delete cluster that is older than 7 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Ignore cluster from being deleted, if it is older than 7 days and does not have the `keep-until` annotation. This is to prevent the deletion of customer clusters in case this app is accidentally deployed to a production MC.
+- Ignore cluster from being deleted, if it is older than 7 days and does not have the `keep-until` label. This is to prevent the deletion of customer clusters in case this app is accidentally deployed to a production MC.
 
 ## [0.9.0] - 2024-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ignore cluster from being deleted, if it is older than 7 days and do not have the `keep-until` annotation. This is to prevent deletion of a customer clusters in case this app is accidentally deployed to a production MC.
+
 ## [0.9.0] - 2024-02-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Ignore cluster from being deleted, if it is older than 7 days and do not have the `keep-until` annotation. This is to prevent deletion of a customer clusters in case this app is accidentally deployed to a production MC.
+- Ignore cluster from being deleted, if it is older than 7 days and does not have the `keep-until` annotation. This is to prevent the deletion of customer clusters in case this app is accidentally deployed to a production MC.
 
 ## [0.9.0] - 2024-02-15
 

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -102,6 +102,14 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *capi.Cluster
 			log.Info(fmt.Sprintf("Found label %s. Cluster will be ignored for deletion", keepUntil))
 			return ctrl.Result{RequeueAfter: 24 * time.Hour}, nil
 		}
+	} else {
+		// ignore cluster from being deleted if it is older than 7 days and do NOT have keep-until label
+		// this is to prevent deletion in a case of accidental deployment of the app to production MCs
+		if time.Since(cluster.CreationTimestamp.Time).Hours() > 24*7 {
+			log.Info(fmt.Sprintf("Cluster is older than 7 days and do not have annotation %s. Cluster will be ignored for deletion", keepUntil))
+			return ctrl.Result{}, nil
+		}
+
 	}
 
 	// immediately delete the cluster if defaultTTL has passed

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -106,7 +106,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *capi.Cluster
 		// ignore cluster from being deleted if it is older than 7 days and do NOT have keep-until label
 		// this is to prevent deletion in a case of accidental deployment of the app to production MCs
 		if time.Since(cluster.CreationTimestamp.Time).Hours() > 24*7 {
-			log.Info(fmt.Sprintf("Cluster is older than 7 days and do not have annotation %s. Cluster will be ignored for deletion", keepUntil))
+			log.Info(fmt.Sprintf("Cluster is older than 7 days and does not have label %s. Cluster will be ignored for deletion", keepUntil))
 			return ctrl.Result{}, nil
 		}
 


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/30431


- Ignore cluster from being deleted, if it is older than 7 days and does not have the `keep-until` annotation. This is to prevent the deletion of customer clusters in case this app is accidentally deployed to a production MC.


This is additional safeguard that we think is necessary for this app.