### PR TITLE
Change label for vintage/capi detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change the label used to detect whether the Cluster is Vintage or CAPI based.
+
 ## [0.10.0] - 2024-04-30
 
 ### Added

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -116,7 +116,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *capi.Cluster
 	if deletionTimeReached(cluster) {
 		if !r.DryRun {
 			// if it's a vintage cluster, we just try to remove the Cluster CR
-			if _, ok := cluster.Labels[vintageReleaseVersion]; ok {
+			if _, ok := cluster.Labels[clusterOperatorVersion]; ok {
 				err := deleteVintageCluster(ctx, log, r.Client, cluster)
 				if err != nil {
 					return ctrl.Result{}, err

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -54,7 +54,7 @@ func TestClusterController(t *testing.T) {
 						Time: time.Now().Add(-defaultTTL),
 					},
 					Labels: map[string]string{
-						"release.giantswarm.io/version": "18.2.1",
+						"cluster-operator.giantswarm.io/version": "5.1.1",
 					},
 					Annotations: map[string]string{},
 					Finalizers: []string{
@@ -187,8 +187,8 @@ func TestClusterController(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 					Labels: map[string]string{
-						keepUntil:                       "2020-12-08",
-						"release.giantswarm.io/version": "18.2.1",
+						keepUntil:                                "2020-12-08",
+						"cluster-operator.giantswarm.io/version": "5.1.1",
 					},
 					Finalizers: []string{
 						"operatorkit.giantswarm.io/cluster-operator-cluster-controller",
@@ -214,7 +214,7 @@ func TestClusterController(t *testing.T) {
 						"kustomize.toolkit.fluxcd.io/name": "flux",
 					},
 					Labels: map[string]string{
-						"release.giantswarm.io/version": "18.2.1",
+						"cluster-operator.giantswarm.io/version": "5.1.1",
 					},
 					Finalizers: []string{
 						"operatorkit.giantswarm.io/cluster-operator-cluster-controller",
@@ -402,7 +402,7 @@ func TestClusterAppDeletion(t *testing.T) {
 						Time: time.Now().Add(-defaultTTL),
 					},
 					Labels: map[string]string{
-						"release.giantswarm.io/version": "18.2.1",
+						"cluster-operator.giantswarm.io/version": "5.1.1",
 					},
 					Annotations: map[string]string{
 						helmReleaseNameAnnotation:      "test",

--- a/controllers/utility.go
+++ b/controllers/utility.go
@@ -32,7 +32,7 @@ const (
 	// fluxLabel is the label for checking if the cluster is created via git-ops
 	fluxLabel = "kustomize.toolkit.fluxcd.io/name"
 
-	vintageReleaseVersion = "release.giantswarm.io/version"
+	clusterOperatorVersion = "cluster-operator.giantswarm.io/version"
 )
 
 func requeue() reconcile.Result {


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

After the changes in CAPA to use the Release CRs; the label `release.giantswarm.io/version` is added there as well.
That makes it an invalid way to detect whether the cluster is CAPI or Vintage.

I propose to use `cluster-operator.giantswarm.io/version` instead, since it's present only in Vintage.

## Checklist

- [x] Update changelog in CHANGELOG.md.

