### PR TITLE
Disable logger development mode to avoid panicking, use zap as logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Disable logger development mode to avoid panicking, use zap as logger.
+
 ## [0.10.1] - 2024-07-02
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&dryRun, "dry-run", false, "Enable dry-run.")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3658